### PR TITLE
Chore: Docker 빌드에서 husky/prepare 비활성화 및 devDeps 미설치

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,11 +39,13 @@
 # ---------- Build ----------
 FROM node:20-bookworm-slim AS builder
 ENV NODE_ENV=production
+# Husky(prepare) 비활성화 및 설치 스크립트 무시
+ENV HUSKY=0
 WORKDIR /app
 
 # deps 먼저 복사 → 캐시 최적화
 COPY package.json package-lock.json* ./
-RUN bash -lc 'if [ -f package-lock.json ]; then npm ci; else npm i; fi'
+RUN bash -lc 'if [ -f package-lock.json ]; then npm ci --omit=dev --ignore-scripts; else npm i --omit=dev --ignore-scripts; fi'
 
 # 소스 복사 후 빌드
 COPY . .


### PR DESCRIPTION
## 📌 PR 제목
[Chore] Docker 빌드 안정화: husky/prepare 비활성화 및 devDeps 미설치

---

## 📝 작업 내용
- Docker 빌드 단계에서 `husky not found`로 실패하던 문제 해결
- `builder` 단계에 다음 적용
  - `HUSKY=0`로 `prepare` 스크립트 비활성화
  - `npm ci --omit=dev --ignore-scripts`로 devDependencies 미설치 및 스크립트 미실행

---

## 🔍 주요 변경 사항
- `Dockerfile`
  - `ENV HUSKY=0` 추가
  - 패키지 설치: `npm ci --omit=dev --ignore-scripts`

---

## ✅ 체크리스트
- [x] 로컬/CI Docker 빌드 통과 확인
- [x] PR 제목 규칙 준수 ([Chore])

---

## 📷 스크린샷 (선택)
- N/A

---

## 🚨 주의사항
- 로컬 개발(husky pre-commit)은 그대로 동작합니다. CI/빌드 환경에서만 hooks 비활성화됩니다.
- CI에서 hooks 실행이 필요하면 해당 단계에서 `HUSKY=1`로 명시적으로 활성화하세요.