### PR TITLE
Fix: 로그인 로직 정리 - 불필요한 콜백/프록시 제거 및 Next.js rewrites 적용

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -36,6 +36,10 @@ const nextConfig = {
         source: '/api/graphql',
         destination: 'http://localhost:4000/graphql',
       },
+      {
+        source: '/auth/:path*',
+        destination: `${process.env.NEXT_PUBLIC_API_BASE}/auth/:path*`,
+      },
     ];
   },
   async headers() {

--- a/src/apis/auth/api.ts
+++ b/src/apis/auth/api.ts
@@ -29,8 +29,8 @@ export const authApi = {
 
 // 소셜 로그인 리다이렉트 함수
 export function redirectToSocialLogin(provider: 'google' | 'kakao' | 'naver') {
-  const baseUrl = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:3001';
-  window.location.href = `${baseUrl}/auth/login-${provider}`;
+  // Next.js rewrites를 통해 백엔드로 프록시
+  window.location.href = `/auth/login-${provider}`;
 }
 
 // Auth Hooks

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -32,8 +32,7 @@ export const metadata: Metadata = {
 
 export default async function RootLayout({ children }: { children: React.ReactNode }) {
   const cookieStore = await cookies();
-  // const isLoggedIn = !!cookieStore.get('accessToken');
-  const isLoggedIn = true;
+  const isLoggedIn = !!cookieStore.get('accessToken');
   const role = cookieStore.get('role')?.value as 'user' | 'admin' | undefined;
 
   return (

--- a/src/components/layout/HeaderShell.tsx
+++ b/src/components/layout/HeaderShell.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useEffect, useMemo, useState } from 'react';
 import { usePathname } from 'next/navigation';
 import { determineHeaderVariant } from '@/utils/getHeaderVariant';
 import Header from '@/components/layout/Header';
@@ -11,13 +12,37 @@ interface Props {
 
 export default function HeaderShell({ isLoggedIn, role }: Props) {
   const pathname = usePathname();
-  const variant = determineHeaderVariant({
-    pathname,
-    isLoggedIn,
-    ...(role ? { role } : {}),
+  const [hasToken, setHasToken] = useState<boolean>(() => {
+    if (typeof window === 'undefined') return Boolean(isLoggedIn);
+    try {
+      return Boolean(localStorage.getItem('accessToken'));
+    } catch {
+      return Boolean(isLoggedIn);
+    }
   });
 
-  console.log('현재 pathname:', pathname);
+  useEffect(() => {
+    const sync = () => {
+      try {
+        setHasToken(Boolean(localStorage.getItem('accessToken')));
+      } catch {
+        setHasToken(Boolean(isLoggedIn));
+      }
+    };
+    sync();
+    window.addEventListener('storage', sync);
+    return () => window.removeEventListener('storage', sync);
+  }, [isLoggedIn]);
+
+  const variant = useMemo(
+    () =>
+      determineHeaderVariant({
+        pathname,
+        isLoggedIn: hasToken || isLoggedIn,
+        ...(role ? { role } : {}),
+      }),
+    [pathname, hasToken, isLoggedIn, role]
+  );
 
   return <Header variant={variant} />;
 }


### PR DESCRIPTION
## 📌 PR 제목
[Fix] 로그인 로직 정리 - 불필요한 콜백/프록시 제거 및 Next.js rewrites 적용

---

## 📝 작업 내용
- OAuth 로그인 플로우 단순화 및 불필요한 파일 제거
- Next.js rewrites를 통한 백엔드 프록시 설정으로 배포 환경 404 오류 해결
- 로그인 후 홈 페이지에서 자동 토큰 재발급 처리

---

## 🔍 주요 변경 사항
- **삭제된 파일들**
  - `src/app/auth/callback/page.tsx` (불필요한 OAuth 콜백 페이지)
  - `src/app/api/auth/[...path]/route.ts` (복잡한 API 프록시)

- **수정된 파일들**
  - `next.config.mjs`: `/auth/:path*` → `${NEXT_PUBLIC_API_BASE}/auth/:path*` rewrite 추가
  - `src/apis/auth/api.ts`: `redirectToSocialLogin` 함수를 `/auth/login-{provider}`로 단순화

- **로그인 플로우 개선**
  - 기존: 버튼 → 프록시 → 백엔드 → 콜백 페이지 → 홈
  - 개선: 버튼 → Next.js rewrites → 백엔드 → 홈 (자동 토큰 재발급)

---

## ✅ 체크리스트
- [x] 로컬 환경에서 로그인 동작 확인
- [x] 배포 환경에서 404 오류 해결 확인
- [x] 불필요한 파일 완전 제거
- [x] PR 제목 규칙 준수 ([Fix])

---

## ## 📷 스크린샷 (선택)
- N/A (기능 개선 작업)

---

## 🚨 주의사항
- Next.js rewrites는 서버 사이드에서 동작하므로 환경변수 `NEXT_PUBLIC_API_BASE`가 올바르게 설정되어야 함
- 로그인 후 홈 페이지에서 `useAuthRedirect` 훅이 자동으로 토큰 재발급을 처리함
- 기존 OAuth 콜백 페이지 로직은 제거되었으므로 백엔드 설정에서 redirect URI를 홈(`/`)으로 설정해야 함