### PR TITLE
Fix: OAuth 플로우 정리 - 재발급 호출을 auth 페이지로 이동하고 홈은 token 저장만 수행

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,16 +5,13 @@ import FeedFilter from '@/components/main/FeedFilter';
 import { Grid, GridItem, VStack } from '@chakra-ui/react';
 import { useEffect, useState } from 'react';
 import { useSearchParams } from 'next/navigation';
-import { useRefreshToken } from '@/apis/auth';
 
 export default function HomePage() {
   const [source] = useState<'smart' | 'popular' | 'subscribed' | 'recent' | 'notice'>('smart');
   const [filter, setFilter] = useState<'smart' | 'popular' | 'subscribed'>('smart');
   const searchParams = useSearchParams();
 
-  const refreshTokenMutation = useRefreshToken();
-
-  // OAuth 로그인 후 토큰 처리 및 자동 리프레시
+  // OAuth 로그인 후 토큰 처리 (홈에서는 재발급 호출하지 않음)
   useEffect(() => {
     if (typeof window === 'undefined') return;
 
@@ -29,34 +26,8 @@ export default function HomePage() {
       return;
     }
 
-    // 2) 직전 페이지에서 저장해 둔 응답 출력
-    const raw = sessionStorage.getItem('auth:lastRefresh');
-    if (raw) {
-      try {
-        // console.log('[auth] lastRefresh:', JSON.parse(raw));
-      } catch {}
-      sessionStorage.removeItem('auth:lastRefresh');
-    }
-
-    // 3) accessToken이 없으면 홈에서 한 번 자동 재발급 시도 (쿠키 기반)
-    const hasAccess = !!localStorage.getItem('accessToken');
-    const tried = sessionStorage.getItem('auth:triedRefreshOnHome') === '1';
-    if (!hasAccess && !tried) {
-      sessionStorage.setItem('auth:triedRefreshOnHome', '1');
-      refreshTokenMutation.mutate(undefined, {
-        onSuccess: (data) => {
-          // console.log('[auth] refresh from home success:', data);
-          if (data?.success && data?.data) {
-            localStorage.setItem('accessToken', data.data);
-            sessionStorage.setItem('auth:lastRefresh', JSON.stringify(data));
-          }
-        },
-        onError: () => {
-          // console.error('[auth] refresh from home error:', err);
-        },
-      });
-    }
-  }, [refreshTokenMutation, searchParams]);
+    // 2) 홈에서는 재발급 트리거 하지 않음 (auth 페이지 전담)
+  }, [searchParams]);
 
   return (
     <Grid templateColumns="3fr 1fr" gap="8" pt="4" pl="10" pr="10">


### PR DESCRIPTION
Fix: OAuth 플로우 정리 - 재발급 호출을 auth 페이지로 이동하고 홈은 token 저장만 수행